### PR TITLE
fix: signup existing user check

### DIFF
--- a/apps/auth/views.py
+++ b/apps/auth/views.py
@@ -404,7 +404,7 @@ def auth_signup_api(request) -> Response:
             return error_response or Response(
                 {"error": "Failed to create user session"}, status=500
             )
-        if user.has_usable_password():
+        if user.password:
             return Response({"error": "User already exists with password."}, status=409)
 
         user.is_active = True


### PR DESCRIPTION
Note: current method use `user_model.Object.get_or_create()` to create a user, which will not call `set_unusable_password`, so `has_usable_password` will return `true`, leading to 409 in normal setup workflow.  